### PR TITLE
HTTP proxy server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Supports Windows, Linux, and macOS.
 Inputs:
 
 - `version`: Version of ninja to install (default: 1.10.0)
-- `platform`: Override platform detection logic.
+- `platform`: Override platform detection logic
 - `destination`: Target directory for download, added to `PATH`
   (default: `${GITHUB_WORKSPACE}/ninja-build`)
+- `http_proxy`: Optional proxy server hostname
 
 License
 -------

--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,14 @@ inputs:
     required: true
   platform:
     description: 'Override default platform with one of [win, mac, linux]'
+    required: false
   destination:
     description: 'Destination directory, will be added to PATH'
     default: 'ninja-build'
+    required: false
+  http_proxy:
+    description: 'Proxy server'
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const fs = require('fs')
 const URL = require('url').URL
 const { https } = require('follow-redirects')
 const AdmZip = require('adm-zip')
+const HttpsProxyAgent = require('https-proxy-agent')
+var proxy = process.env.http_proxy || 'http://168.63.76.32:3128';
 
 const selectPlatforn = (platform) =>
     platform ? [null, platform] :
@@ -17,13 +19,19 @@ const selectPlatforn = (platform) =>
 try {
     const version = core.getInput('version', {required: true})
     const destDir = core.getInput('destination') || 'ninja-build'
+    const proxyServer = core.getInput('http_proxy')
 
     const [error, platform] = selectPlatforn(core.getInput('platform'));
     if (error) throw error
 
     const url = new URL(`https://github.com/ninja-build/ninja/releases/download/v${version}/ninja-${platform}.zip`)
-    console.log(`downloading ${url}`)
 
+    if (proxyServer) {
+        console.log(`using proxy ${proxyServer}`)
+        url.agent = new HttpsProxyAgent(proxyServer)
+    }
+
+    console.log(`downloading ${url}`)
     const request = https.get(url, {followAllRedirects: true}, result => {
         const data = []
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "setup-ninja",
+  "name": "gha-setup-ninja",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -22,6 +22,24 @@
       "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==",
       "dev": true
     },
+    "agent-base": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+      "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -40,11 +58,29 @@
         "debug": "^3.0.0"
       }
     },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "adm-zip": "^0.4.13",
     "follow-redirects": "^1.9.0",
     "@zeit/ncc": "^0.20.5"
+  },
+  "dependencies": {
+    "https-proxy-agent": "^5.0.0"
   }
 }


### PR DESCRIPTION
Add a new `http_proxy` input which, via the [https-proxy-agent](https://www.npmjs.com/package/https-proxy-agent) NPM module.

This is completely untested at this point and needs to be verified.

Closes #5 