### PR TITLE
Update default Ninja version to 1.10.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         image: [ 'windows-latest', 'ubuntu-latest', 'macos-latest' ]
-        version: [ '1.9.0', '1.10.0' ]
+        version: [ '1.9.0', '1.10.2' ]
 
     steps:
       - uses: actions/checkout@master

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Supports Windows, Linux, and macOS.
 
 Inputs:
 
-- `version`: Version of ninja to install (default: 1.10.0)
+- `version`: Version of ninja to install (default: 1.10.2)
 - `platform`: Override platform detection logic
 - `destination`: Target directory for download, added to `PATH`
   (default: `${GITHUB_WORKSPACE}/ninja-build`)

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
 inputs:
   version:
     description: 'Version of ninja-build to install'
-    default: '1.10.0'
+    default: '1.10.2'
     required: true
   platform:
     description: 'Override default platform with one of [win, mac, linux]'


### PR DESCRIPTION
Updates the default Ninja version to [1.10.2](https://github.com/ninja-build/ninja/releases/tag/v1.10.2).