### PR TITLE
Upgrade the tests for the current version of Ninja

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         image: [ 'windows-latest', 'ubuntu-latest', 'macos-latest' ]
-        version: [ '1.9.0', '1.10.2' ]
+        version: [ '1.9.0', '1.10.2', '1.11.1' ]
 
     steps:
       - uses: actions/checkout@master

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Supports Windows, Linux, and macOS.
 
 Inputs:
 
-- `version`: Version of ninja to install (default: 1.10.2)
+- `version`: Version of ninja to install (default: 1.11.1)
 - `platform`: Override platform detection logic
 - `destination`: Target directory for download, added to `PATH`
   (default: `${GITHUB_WORKSPACE}/ninja-build`)


### PR DESCRIPTION
*  #20 did not update the GitHub Action test to match https://github.com/ninja-build/ninja/releases

@seanmiddleditch Your review, please.