### PR TITLE
Update runtime to node20.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - uses: ./
         with:
           version: '${{ matrix.version }}'

--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ inputs:
     description: 'Proxy server'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -335,7 +335,6 @@ const URL = __webpack_require__(835).URL
 const { https } = __webpack_require__(549)
 const AdmZip = __webpack_require__(639)
 const HttpsProxyAgent = __webpack_require__(338)
-var proxy = process.env.http_proxy || 'http://168.63.76.32:3128';
 
 const selectPlatforn = (platform) =>
     platform ? [null, platform] :

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ const URL = require('url').URL
 const { https } = require('follow-redirects')
 const AdmZip = require('adm-zip')
 const HttpsProxyAgent = require('https-proxy-agent')
-var proxy = process.env.http_proxy || 'http://168.63.76.32:3128';
 
 const selectPlatforn = (platform) =>
     platform ? [null, platform] :


### PR DESCRIPTION
Reacting to [GitHub Actions' deprecation of Node.js 16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), this PR updates the action's runtime to Node.js 20. After this PR is merged, a new version 5 should be released.

Fixes #22