### PR TITLE
Add Ninja 1.12.1 support, including improved platform detection

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        image: [ 'windows-latest', 'ubuntu-latest', 'macos-latest' ]
+        image: [ 'windows-latest', 'ubuntu-latest', 'ubuntu-24.04-arm', 'macos-latest' ]
         version: [ '1.9.0', '1.10.2', '1.11.1', '1.12.1' ]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,14 @@ jobs:
       matrix:
         image: [ 'windows-latest', 'ubuntu-latest', 'ubuntu-24.04-arm', 'macos-latest' ]
         version: [ '1.9.0', '1.10.2', '1.11.1', '1.12.1' ]
+        exclude:
+          # ARM binaries aren't available until 1.12
+          - image: 'ubuntu-24.04-arm'
+            version: '1.11.1'
+          - image: 'ubuntu-24.04-arm'
+            version: '1.10.2'
+          - image: 'ubuntu-24.04-arm'
+            version: '1.9.0'
 
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         image: [ 'windows-latest', 'ubuntu-latest', 'macos-latest' ]
-        version: [ '1.9.0', '1.10.2', '1.11.1' ]
+        version: [ '1.9.0', '1.10.2', '1.11.1', '1.12.1' ]
 
     steps:
       - uses: actions/checkout@master

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Supports Windows, Linux, and macOS.
 
 Inputs:
 
-- `version`: Version of ninja to install (default: 1.11.1)
+- `version`: Version of ninja to install (default: 1.12.1)
 - `platform`: Override platform detection logic
 - `destination`: Target directory for download, added to `PATH`
   (default: `${GITHUB_WORKSPACE}/ninja-build`)

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,10 @@ branding:
 inputs:
   version:
     description: 'Version of ninja-build to install'
-    default: '1.11.1'
+    default: '1.12.1'
     required: true
   platform:
-    description: 'Override default platform with one of [win, mac, linux]'
+    description: 'Override default platform with one of [win, mac, linux, winarm64, linux-aarch64]'
     required: false
   destination:
     description: 'Destination directory, will be added to PATH'

--- a/dist/index.js
+++ b/dist/index.js
@@ -31424,15 +31424,15 @@ module.exports = parseParams
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
-const core = __nccwpck_require__(2186)
-const process = __nccwpck_require__(7282)
-const spawn = (__nccwpck_require__(2081).spawnSync)
-const path = __nccwpck_require__(1017)
-const fs = __nccwpck_require__(7147)
-const URL = (__nccwpck_require__(7310).URL)
-const { https } = __nccwpck_require__(7707)
-const AdmZip = __nccwpck_require__(6761)
-const HttpsProxyAgent = __nccwpck_require__(7219)
+const core = require('@actions/core')
+const process = require('process')
+const spawn = require('child_process').spawnSync
+const path = require('path')
+const fs = require('fs')
+const URL = require('url').URL
+const { https } = require('follow-redirects')
+const AdmZip = require('adm-zip')
+const HttpsProxyAgent = require('https-proxy-agent')
 
 function selectPlatform(platform, version) {
     if (platform) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -31424,15 +31424,15 @@ module.exports = parseParams
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
-const core = require('@actions/core')
-const process = require('process')
-const spawn = require('child_process').spawnSync
-const path = require('path')
-const fs = require('fs')
-const URL = require('url').URL
-const { https } = require('follow-redirects')
-const AdmZip = require('adm-zip')
-const HttpsProxyAgent = require('https-proxy-agent')
+const core = __nccwpck_require__(2186)
+const process = __nccwpck_require__(7282)
+const spawn = (__nccwpck_require__(2081).spawnSync)
+const path = __nccwpck_require__(1017)
+const fs = __nccwpck_require__(7147)
+const URL = (__nccwpck_require__(7310).URL)
+const { https } = __nccwpck_require__(7707)
+const AdmZip = __nccwpck_require__(6761)
+const HttpsProxyAgent = __nccwpck_require__(7219)
 
 function selectPlatform(platform, version) {
     if (platform) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -31424,68 +31424,29 @@ module.exports = parseParams
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
-const core = require('@actions/core')
-const process = require('process')
-const spawn = require('child_process').spawnSync
-const path = require('path')
-const fs = require('fs')
-const URL = require('url').URL
-const { https } = require('follow-redirects')
-const AdmZip = require('adm-zip')
-const HttpsProxyAgent = require('https-proxy-agent')
+const core = __nccwpck_require__(2186)
+const process = __nccwpck_require__(7282)
+const spawn = (__nccwpck_require__(2081).spawnSync)
+const path = __nccwpck_require__(1017)
+const fs = __nccwpck_require__(7147)
+const URL = (__nccwpck_require__(7310).URL)
+const { https } = __nccwpck_require__(7707)
+const AdmZip = __nccwpck_require__(6761)
+const HttpsProxyAgent = __nccwpck_require__(7219)
 
-function selectPlatform(platform, version) {
-    if (platform) {
-        return [null, platform]
-    }
-    
-    let major, minor, patch = version.split('.').map((s) => parseInt(s))
-    if (process.platform === 'win32') {
-        if (process.arch === 'arm64') {
-            if (major < 1 || major == 1 && minor < 12) {
-                return [new Error(`Windows ARM builds are only available for 1.12.0 and later`), '']
-            }
-            else {
-                return [null, 'winarm64']
-            }
-        }
-        else if (process.arch === 'x64') {
-            return [null, 'win']
-        }
-        else {
-            return [new Error(`Unsupported architecture '${process.arch}'`), '']
-        }
-    }
-    else if (process.platform === 'linux') {
-        if (process.arch === 'arm64') {
-            if (major < 1 || major == 1 && minor < 12) {
-                return [new Error(`Linux ARM builds are only available for 1.12.0 and later`), '']
-            }
-            else {
-                return [null, 'linux-aarch64']
-            }
-        }
-        else if (process.arch === 'x64') {
-            return [null, 'linux']
-        }
-        else {
-            return [new Error(`Unsupported architecture '${process.arch}'`), '']
-        }
-    }
-    else if (process.platform === 'darwin') {
-        return [null, 'mac']
-    }
-    else {
-        return [new Error(`Unsupported platform '${process.platform}'`), '']
-    }
-}
+const selectPlatforn = (platform) =>
+    platform ? [null, platform] :
+    process.platform === 'win32' ? [null, 'win'] :
+    process.platform === 'darwin' ? [null, 'mac'] :
+    process.platform === 'linux' ? [null, 'linux'] :
+    [new Error(`Unsupported platform '${process.platform}'`), '']
 
 try {
     const version = core.getInput('version', {required: true})
     const destDir = core.getInput('destination') || 'ninja-build'
     const proxyServer = core.getInput('http_proxy')
 
-    const [error, platform] = selectPlatform(core.getInput('platform'), version);
+    const [error, platform] = selectPlatforn(core.getInput('platform'));
     if (error) throw error
 
     const url = new URL(`https://github.com/ninja-build/ninja/releases/download/v${version}/ninja-${platform}.zip`)
@@ -31546,7 +31507,6 @@ try {
 } catch (error) {
     core.setFailed(error.message)
 }
-
 
 })();
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -31434,58 +31434,19 @@ const { https } = __nccwpck_require__(7707)
 const AdmZip = __nccwpck_require__(6761)
 const HttpsProxyAgent = __nccwpck_require__(7219)
 
-function selectPlatform(platform, version) {
-    if (platform) {
-        return [null, platform]
-    }
-    
-    let major, minor, patch = version.split('.').map((s) => parseInt(s))
-    if (process.platform === 'win32') {
-        if (process.arch === 'arm64') {
-            if (major < 1 || major == 1 && minor < 12) {
-                return [new Error(`Windows ARM builds are only available for 1.12.0 and later`), '']
-            }
-            else {
-                return [null, 'winarm64']
-            }
-        }
-        else if (process.arch === 'x64') {
-            return [null, 'win']
-        }
-        else {
-            return [new Error(`Unsupported architecture '${process.arch}'`), '']
-        }
-    }
-    else if (process.platform === 'linux') {
-        if (process.arch === 'arm64') {
-            if (major < 1 || major == 1 && minor < 12) {
-                return [new Error(`Linux ARM builds are only available for 1.12.0 and later`), '']
-            }
-            else {
-                return [null, 'linux-aarch64']
-            }
-        }
-        else if (process.arch === 'x64') {
-            return [null, 'linux']
-        }
-        else {
-            return [new Error(`Unsupported architecture '${process.arch}'`), '']
-        }
-    }
-    else if (process.platform === 'darwin') {
-        return [null, 'mac']
-    }
-    else {
-        return [new Error(`Unsupported platform '${process.platform}'`), '']
-    }
-}
+const selectPlatforn = (platform) =>
+    platform ? [null, platform] :
+    process.platform === 'win32' ? [null, 'win'] :
+    process.platform === 'darwin' ? [null, 'mac'] :
+    process.platform === 'linux' ? [null, 'linux'] :
+    [new Error(`Unsupported platform '${process.platform}'`), '']
 
 try {
     const version = core.getInput('version', {required: true})
     const destDir = core.getInput('destination') || 'ninja-build'
     const proxyServer = core.getInput('http_proxy')
 
-    const [error, platform] = selectPlatform(core.getInput('platform'), version)
+    const [error, platform] = selectPlatforn(core.getInput('platform'));
     if (error) throw error
 
     const url = new URL(`https://github.com/ninja-build/ninja/releases/download/v${version}/ninja-${platform}.zip`)

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ try {
     const destDir = core.getInput('destination') || 'ninja-build'
     const proxyServer = core.getInput('http_proxy')
 
-    const [error, platform] = selectPlatform(core.getInput('platform'), version);
+    const [error, platform] = selectPlatform(core.getInput('platform'), version)
     if (error) throw error
 
     const url = new URL(`https://github.com/ninja-build/ninja/releases/download/v${version}/ninja-${platform}.zip`)

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function selectPlatform(platform, version) {
     
     let major, minor, patch = version.split('.').map((s) => parseInt(s))
     if (process.platform === 'win32') {
-        if (process.arch == 'arm64') {
+        if (process.arch === 'arm64') {
             if (major < 1 || major == 1 && minor < 12) {
                 return [new Error(`Windows ARM builds are only available for 1.12.0 and later`), '']
             }
@@ -31,7 +31,7 @@ function selectPlatform(platform, version) {
         }
     }
     else if (process.platform === 'linux') {
-        if (process.arch == 'arm64') {
+        if (process.arch === 'arm64') {
             if (major < 1 || major == 1 && minor < 12) {
                 return [new Error(`Linux ARM builds are only available for 1.12.0 and later`), '']
             }

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ try {
     const destDir = core.getInput('destination') || 'ninja-build'
     const proxyServer = core.getInput('http_proxy')
 
-    const [error, platform] = selectPlatform(core.getInput('platform'), version)
+    const [error, platform] = selectPlatform(core.getInput('platform'), version);
     if (error) throw error
 
     const url = new URL(`https://github.com/ninja-build/ninja/releases/download/v${version}/ninja-${platform}.zip`)

--- a/index.js
+++ b/index.js
@@ -8,19 +8,58 @@ const { https } = require('follow-redirects')
 const AdmZip = require('adm-zip')
 const HttpsProxyAgent = require('https-proxy-agent')
 
-const selectPlatforn = (platform) =>
-    platform ? [null, platform] :
-    process.platform === 'win32' ? [null, 'win'] :
-    process.platform === 'darwin' ? [null, 'mac'] :
-    process.platform === 'linux' ? [null, 'linux'] :
-    [new Error(`Unsupported platform '${process.platform}'`), '']
+function selectPlatform(platform, version) {
+    if (platform) {
+        return [null, platform]
+    }
+    
+    let major, minor, patch = version.split('.').map((s) => parseInt(s))
+    if (process.platform === 'win32') {
+        if (process.arch == 'arm64') {
+            if (major < 1 || major == 1 && minor < 12) {
+                return [new Error(`Windows ARM builds are only available for 1.12.0 and later`), '']
+            }
+            else {
+                return [null, 'winarm64']
+            }
+        }
+        else if (process.arch === 'x64') {
+            return [null, 'win']
+        }
+        else {
+            return [new Error(`Unsupported architecture '${process.arch}'`), '']
+        }
+    }
+    else if (process.platform === 'linux') {
+        if (process.arch == 'arm64') {
+            if (major < 1 || major == 1 && minor < 12) {
+                return [new Error(`Linux ARM builds are only available for 1.12.0 and later`), '']
+            }
+            else {
+                return [null, 'linux-aarch64']
+            }
+        }
+        else if (process.arch === 'x64') {
+            return [null, 'linux']
+        }
+        else {
+            return [new Error(`Unsupported architecture '${process.arch}'`), '']
+        }
+    }
+    else if (process.platform === 'darwin') {
+        return [null, 'mac']
+    }
+    else {
+        return [new Error(`Unsupported platform '${process.platform}'`), '']
+    }
+}
 
 try {
     const version = core.getInput('version', {required: true})
     const destDir = core.getInput('destination') || 'ninja-build'
     const proxyServer = core.getInput('http_proxy')
 
-    const [error, platform] = selectPlatforn(core.getInput('platform'));
+    const [error, platform] = selectPlatform(core.getInput('platform'), version);
     if (error) throw error
 
     const url = new URL(`https://github.com/ninja-build/ninja/releases/download/v${version}/ninja-${platform}.zip`)


### PR DESCRIPTION
This adds Ninja 1.12.1 (and 1.12.0) support. Ninja ships Linux and Windows ARM binaries since 1.12.0, so I've added some logic to account for that (context: https://github.com/ninja-build/ninja/releases/tag/v1.12.0)

I unfortunately have no way to test if the ARM support works, as Github doesn't have public ARM runners available.

Feel free to roast me on my JS, I normally don't write in it :) I figured the new logic was too complex to shove into a series of ternaries.

I spent way too much time trying to minimize the whitespace changes in dist/index.js, I think there's something up with the file. Saving the file even without formatting creates thousands of whitespace changes that are really hard to get git to ignore.