### PR TITLE
Add ubuntu-24.04-arm to the testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        image: [ 'windows-latest', 'ubuntu-latest', 'macos-latest' ]
+        image: [ 'windows-latest', 'ubuntu-latest', 'macos-latest', 'ubuntu-24.04-arm']
         version: [ '1.9.0', '1.10.2', '1.11.1' ]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,9 @@ jobs:
     runs-on: ${{ matrix.image }}
 
     strategy:
+      fail-fast: false
       matrix:
-        image: [ 'windows-latest', 'ubuntu-latest', 'macos-latest', 'ubuntu-24.04-arm']
+        image: [ 'windows-latest', 'ubuntu-latest', 'macos-latest', 'ubuntu-24.04-arm' ]
         version: [ '1.9.0', '1.10.2', '1.11.1' ]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         image: [ 'windows-latest', 'ubuntu-latest', 'macos-latest', 'ubuntu-24.04-arm' ]
-        version: [ '1.9.0', '1.10.2', '1.11.1' ]
+        version: [ '1.9.0', '1.10.2', '1.11.1', '1.12.1' ]
 
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
[Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) `ubuntu-24.04-arm`

https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip is not ARM compatible.
* https://github.com/ninja-build/ninja/releases -->
    * https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux-aarch64.zip in v1.12.0 and later.

* #17
* #29