### PR TITLE
GitHub Action to use on different operating systems

### DIFF
--- a/.github/workflows/use_on_intel_and_arm.yml
+++ b/.github/workflows/use_on_intel_and_arm.yml
@@ -1,0 +1,28 @@
+name: use
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  use:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-13          # Intel
+          - macos-latest      # ARM
+          - ubuntu-24.04      # Intel
+          - ubuntu-24.04-arm  # ARM
+          - windows-latest    # Intel
+          - windows-2025.     # Intel
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 23.x
+    - uses: seanmiddleditch/gha-setup-ninja@master
+    - uses: seanmiddleditch/gha-setup-ninja@v5
+      with:
+        version: 1.12.1
+    # The next one should fail on Ubuntu ARM until there is a new release to npm
+    - uses: seanmiddleditch/gha-setup-ninja@v5

--- a/.github/workflows/use_on_intel_and_arm.yml
+++ b/.github/workflows/use_on_intel_and_arm.yml
@@ -21,8 +21,8 @@ jobs:
       with:
         node-version: 23.x
     - uses: seanmiddleditch/gha-setup-ninja@master
+    # The next two will both fail on Ubuntu ARM until there is a new release to npm
     - uses: seanmiddleditch/gha-setup-ninja@v5
       with:
         version: 1.12.1
-    # The next one should fail on Ubuntu ARM until there is a new release to npm
     - uses: seanmiddleditch/gha-setup-ninja@v5

--- a/.github/workflows/use_on_intel_and_arm.yml
+++ b/.github/workflows/use_on_intel_and_arm.yml
@@ -14,7 +14,7 @@ jobs:
           - ubuntu-24.04      # Intel
           - ubuntu-24.04-arm  # ARM
           - windows-latest    # Intel
-          - windows-2025.     # Intel
+          - windows-2025      # Intel
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/setup-node@v4


### PR DESCRIPTION
Just a proof of the need for a new [release](https://github.com/seanmiddleditch/gha-setup-ninja/releases) to ~npm~ [GitHub Actions Marketplace](https://github.com/marketplace/actions/install-ninja-build-tool) to support ___ubuntu-24.04-arm___.